### PR TITLE
(Fix) watch field nullable if as a resource was specified a method

### DIFF
--- a/src/Common/TsVectorSubscriber.php
+++ b/src/Common/TsVectorSubscriber.php
@@ -191,6 +191,10 @@ class TsVectorSubscriber implements EventSubscriber
     private function isWatchFieldNullable(\ReflectionClass $class, TsVector $annotation)
     {
         foreach ($annotation->fields as $fieldName) {
+            if ($class->hasMethod($fieldName)) {
+                continue;
+            }
+
             $property = $class->getProperty($fieldName);
             /** @var Column $propAnnot */
             $propAnnot = $this->reader->getPropertyAnnotation($property, Column::class);


### PR DESCRIPTION
Based on your code I can assume that it supports a method as a source of string
But in the method isWatchFieldNullable you don't consider that